### PR TITLE
xml2array parsing bug

### DIFF
--- a/soapclient/SforceBaseClient.php
+++ b/soapclient/SforceBaseClient.php
@@ -1128,9 +1128,9 @@ class SObject {
 							$result = $value;
 						}
 
-						//Set the attributes too.
-						if(isset($attributes) && isset($attributes['xsi:nil'])) {
-								$result = $attributes['xsi:nil'];
+						//Check for nil and ignore other attributes.
+						if (isset($attributes) && isset($attributes['xsi:nil']) && !strcasecmp($attributes['xsi:nil'], 'true')) {
+							$result = null;
 						}
 						break;
 				}


### PR DESCRIPTION
When SObject->convertFields calls SObject->xml2array, any field with an attribute of xsi:nil has it's value overwritten with whatever xsi:nil is set to.
