### PR TITLE
Updates to parse SearchResult...similar to the way QueryResult is parsed

### DIFF
--- a/soapclient/SforceBaseClient.php
+++ b/soapclient/SforceBaseClient.php
@@ -888,10 +888,7 @@ class SforceBaseClient {
 }
 
 class SforceSearchResult {
-	public $queryLocator;
-	public $done;
 	public $searchRecords;
-	public $size;
 
 	public function __construct($response) {
 


### PR DESCRIPTION
The first commit adds the SforceSearchResult class and updates the search method on SforceBaseClient to use the new class.

The second commit removes the unused properties from the SforceSearchResult class (size,done,and queryLocator are not part of the SearchResult).
