### PR TITLE
Make QueryResult and sObject objects smarter

### DIFF
--- a/soapclient/SforceBaseClient.php
+++ b/soapclient/SforceBaseClient.php
@@ -949,12 +949,10 @@ class QueryResult implements Iterator{
 			if (isset($response->records)) {
 				if (is_array($response->records)) {
 					foreach ($response->records as $record) {
-						$sobject = new SObject($record);
-						array_push($this->records, $sobject);
+						array_push($this->records, $record);
 					};
 				} else {
-					$sobject = new SObject($response->records);
-					array_push($this->records, $sobject);
+					array_push($this->records, $record);
 				}
 			}
 		}
@@ -966,7 +964,7 @@ class QueryResult implements Iterator{
 	public function rewind() { $this->pointer = 0; }
 	public function next() { ++$this->pointer; }
 	public function key() { return $this->pointer; }
-	public function current() { return $this->records[$this->pointer]; }
+	public function current() { return new SObject($this->records[$this->pointer]); }
 	
 	public function valid() {
 		while ($this->pointer >= count($this->records)) {


### PR DESCRIPTION
Added the [Iterator interface](http://us2.php.net/manual/en/class.iterator.php) to the QueryResult object, which allows users to go:

``` php
<?php
$QueryResult = $sf->query('SELECT Id, Name FROM Lead');
foreach($QueryResult as $lead) {
    print_r($lead); // sObject
}
```

looping through the QueryResult object itself, rather than having to put `$QueryResult->records` in the foreach loop.

QueryResult also calls the `queryMore()` function automatically as it reaches the end of its own result list, if there's more to be fetched, so the user doesn't have to keep track of calling that on their own.

Also added the `__get()` and `__isset()` [overload](http://us2.php.net/manual/en/language.oop5.overloading.php#object.get) methods to the `sObject` class to not require people to delve into the "fields" property:

``` php
<?php
// Instead of:
$foo = $sObj->fields->Foo__c;

// Just do:
$foo = $sObj->Foo__c;
```
