### PR TITLE
small fix for SforcePartnerClient

### DIFF
--- a/soapclient/SforcePartnerClient.php
+++ b/soapclient/SforcePartnerClient.php
@@ -42,8 +42,8 @@ require_once ('SforceBaseClient.php');
  // string content into the parsed output and loses the tag name. Removing the
  // xsi:type forces PHP SOAP to just leave the tags intact
  class SforceSoapClient extends SoapClient {
-   function __doRequest($request, $location, $action, $version) {
-     $response = parent::__doRequest($request, $location, $action, $version);
+   function __doRequest($request, $location, $action, $version, $one_way=0) {
+     $response = parent::__doRequest($request, $location, $action, $version, $one_way);
 
      // Quick check to only parse the XML here if we think we need to
      if (strpos($response, '<sf:OldValue') === false && strpos($response, '<sf:NewValue') === false) {


### PR DESCRIPTION
Fixed method signature of SfoceSoapClient->__doRequest in SforcePartnerClient.php to match PHP's native SoapClient method (prevents E_STRICT error)
