### PR TITLE
Added orgWideEmailAddressId to SforceEmail.php

### DIFF
--- a/soapclient/SforceEmail.php
+++ b/soapclient/SforceEmail.php
@@ -81,6 +81,10 @@ class SingleEmailMessage extends Email {
     $this->htmlBody = $htmlBody;
   }
 
+  public function setOrgWideEmailAddressId($orgWideEmailAddressId) {
+    $this->orgWideEmailAddressId = $orgWideEmailAddressId;
+  }
+
   public function setPlainTextBody($plainTextBody) {
     $this->plainTextBody = $plainTextBody;
   }


### PR DESCRIPTION
I had the need to trigger an email from our website, but it needed to use an org wide email address which isn't supported by the toolkit. I've added this and am contributing the change back.
