### PR TITLE
Fixed problem with 0 as needle in in_array()

### DIFF
--- a/soapclient/SforceBaseClient.php
+++ b/soapclient/SforceBaseClient.php
@@ -1003,7 +1003,7 @@ class SObject {
 		}
 
 		foreach ($response as $responseKey => $responseValue) {
-			if (in_array($responseKey, array('Id', 'type', 'any'))) {
+			if (in_array(strval($responseKey), array('Id', 'type', 'any'))) {
 				continue;
 			}
 			$this->$responseKey = $responseValue;


### PR DESCRIPTION
This fix for case $responseKey = 0, in this case in_array returns 'true', so record with key = 0 will lost.
