### PR TITLE
Extended base class and fixed fatal errors

### DIFF
--- a/soapclient/SforceBaseClient.php
+++ b/soapclient/SforceBaseClient.php
@@ -556,9 +556,18 @@ class SforceBaseClient {
 	protected function _convertToAny($fields) {
 		$anyString = '';
 		foreach ($fields as $key => $value) {
-			$anyString = $anyString . '<' . $key . '>' . $value . '</' . $key . '>';
+			$anyString = $anyString . '<' . $key . '>' . $this->_sanitizeValue($value) . '</' . $key . '>';		// scavix
 		}
 		return $anyString;
+	}
+	
+	/**
+	 * Added by Scavix Software 4/2015
+	 */
+	protected function _sanitizeValue($value) {
+		if((strpos($value, '&') !== false) || (strpos($value, '<') !== false) || (strpos($value, '>') !== false))
+			return '<![CDATA['.$value.']]>';
+		return $value;
 	}
 
 	protected function _create($arg) {

--- a/soapclient/SforceBaseClient.php
+++ b/soapclient/SforceBaseClient.php
@@ -173,7 +173,6 @@ class SforceBaseClient {
 	}
 	
 	/**
-	 * // SCAVIX
 	 * Use existing session id for this API connection
 	 *
 	 * @param string $sessionid   Session ID


### PR DESCRIPTION
We extended the SOAP base class with a method to allow re-use of authorized sessions.
Additionally the sessionHeader was added to the SOAP header without check for existance, so there was an empty header thus beeing invalid. This has been fixed.
