### PR TITLE
Chunk large delete requests

### DIFF
--- a/soapclient/SforceBaseClient.php
+++ b/soapclient/SforceBaseClient.php
@@ -578,9 +578,19 @@ class SforceBaseClient {
 	 */
 	public function delete($ids) {
 		$this->setHeaders("delete");
-		$arg = new stdClass();
-		$arg->ids = $ids;
-		return $this->sforce->delete($arg)->result;
+		if(count($ids) > 200) {
+			$chunked_ids = array_chunk($ids, 200);
+			foreach($chunked_ids as $cids) {
+				$arg = new stdClass;
+				$arg->ids = $cids;
+				$result = $this->sforce->delete($arg)->result;
+			}
+		} else {
+			$arg = new stdClass;
+			$arg->ids = $ids;
+			$result = $this->sforce->delete($arg)->result;
+		}
+		return $result;
 	}
 
 	/**

--- a/soapclient/SforceBaseClient.php
+++ b/soapclient/SforceBaseClient.php
@@ -579,11 +579,12 @@ class SforceBaseClient {
 	public function delete($ids) {
 		$this->setHeaders("delete");
 		if(count($ids) > 200) {
+			$result = array();
 			$chunked_ids = array_chunk($ids, 200);
 			foreach($chunked_ids as $cids) {
 				$arg = new stdClass;
 				$arg->ids = $cids;
-				$result = $this->sforce->delete($arg)->result;
+				$result = array_merge($result, $this->sforce->delete($arg)->result);
 			}
 		} else {
 			$arg = new stdClass;


### PR DESCRIPTION
In version 7.0 and later of the API, you can pass a maximum of 200 object IDs to the delete() call. This change chunks large deletions into batches of 200.