### PR TITLE
Array key references break argument processing

### DIFF
--- a/soapclient/SforceEnterpriseClient.php
+++ b/soapclient/SforceEnterpriseClient.php
@@ -50,7 +50,8 @@ class SforceEnterpriseClient extends SforceBaseClient {
    * @return SaveResult
    */
   public function create($sObjects, $type) {
-    foreach ($sObjects as &$sObject) {
+    $arg = []
+    foreach ($sObjects as $sObject) {
     	// FIX for fieldsToNull issue - allow array in fieldsToNull (STEP #1)
    		$xmlStr = '';
     	if(isset($sObject->fieldsToNull) && is_array($sObject->fieldsToNull)) {
@@ -60,15 +61,15 @@ class SforceEnterpriseClient extends SforceBaseClient {
     	}
     	// ------
     	
-      $sObject = new SoapVar($sObject, SOAP_ENC_OBJECT, $type, $this->namespace);
+      $soapObject = new SoapVar($sObject, SOAP_ENC_OBJECT, $type, $this->namespace);
 
     	// FIX for fieldsToNull issue - allow array in fieldsToNull (STEP #2)
     	if($xmlStr != '') {
-    		$sObject->enc_value->fieldsToNull = new SoapVar(new SoapVar($xmlStr, XSD_ANYXML), SOAP_ENC_ARRAY);
+    		$soapObject->enc_value->fieldsToNull = new SoapVar(new SoapVar($xmlStr, XSD_ANYXML), SOAP_ENC_ARRAY);
     	}
     	// ------
+    	$arg[] = $soapObject;
     }
-    $arg = $sObjects;
 
     return parent::_create(new SoapParam($arg, "sObjects"));
   }
@@ -82,7 +83,9 @@ class SforceEnterpriseClient extends SforceBaseClient {
    */
   public function update($sObjects, $type, $assignment_header = NULL, $mru_header = NULL) {
 
-    foreach ($sObjects as &$sObject) {
+	$arg = new stdClass;
+    	$arg->sObjects = [];
+    foreach ($sObjects as $sObject) {
 
     	// FIX for fieldsToNull issue - allow array in fieldsToNull (STEP #1)
    		$xmlStr = '';
@@ -93,16 +96,16 @@ class SforceEnterpriseClient extends SforceBaseClient {
     	}
     	// ------
     	
-    	$sObject = new SoapVar($sObject, SOAP_ENC_OBJECT, $type, $this->namespace);
+    	$soapObject = new SoapVar($sObject, SOAP_ENC_OBJECT, $type, $this->namespace);
     	
     	// FIX for fieldsToNull issue - allow array in fieldsToNull (STEP #2)
     	if($xmlStr != '') {
-    		$sObject->enc_value->fieldsToNull = new SoapVar(new SoapVar($xmlStr, XSD_ANYXML), SOAP_ENC_ARRAY);
+    		$soapObject->enc_value->fieldsToNull = new SoapVar(new SoapVar($xmlStr, XSD_ANYXML), SOAP_ENC_ARRAY);
     	}
     	// ------
+    	$arg->sObjects[] = $soapObject;
     }
-    $arg = new stdClass;
-    $arg->sObjects = $sObjects;
+    
     return parent::_update($arg);
   }
 
@@ -119,8 +122,9 @@ class SforceEnterpriseClient extends SforceBaseClient {
    */
   public function upsert($ext_Id, $sObjects, $type = 'Contact') {
     $arg = new stdClass;
+    $arg->sObjects = [];
     $arg->externalIDFieldName = new SoapVar($ext_Id, XSD_STRING, 'string', 'http://www.w3.org/2001/XMLSchema');
-    foreach ($sObjects as &$sObject) {
+    foreach ($sObjects as $sObject) {
       // FIX for fieldsToNull issue - allow array in fieldsToNull (STEP #1)
    	  $xmlStr = '';
       if(isset($sObject->fieldsToNull) && is_array($sObject->fieldsToNull)) {
@@ -130,15 +134,16 @@ class SforceEnterpriseClient extends SforceBaseClient {
       }
       // ------
     	
-      $sObject = new SoapVar($sObject, SOAP_ENC_OBJECT, $type, $this->namespace);
+      $soapObject = new SoapVar($sObject, SOAP_ENC_OBJECT, $type, $this->namespace);
 
 	  // FIX for fieldsToNull issue - allow array in fieldsToNull (STEP #2)
 	  if($xmlStr != '') {
-	  	$sObject->enc_value->fieldsToNull = new SoapVar(new SoapVar($xmlStr, XSD_ANYXML), SOAP_ENC_ARRAY);
+	  	$soapObject->enc_value->fieldsToNull = new SoapVar(new SoapVar($xmlStr, XSD_ANYXML), SOAP_ENC_ARRAY);
 	  }
 	  // ------
+	  $arg->sObjects[] = $soapObject;
     }
-    $arg->sObjects = $sObjects;
+   
     return parent::_upsert($arg);
   }
 


### PR DESCRIPTION
To prevent encountering the "Array key references break argument processing" (https://bugs.php.net/bug.php?id=70993) bug on PHP 7.0.1
Replaced all array key references.