### PR TITLE
Use __construct instead of class name for constructor

### DIFF
--- a/soapclient/SforcePartnerClient.php
+++ b/soapclient/SforcePartnerClient.php
@@ -74,7 +74,7 @@ require_once ('SforceBaseClient.php');
 class SforcePartnerClient extends SforceBaseClient {
   const PARTNER_NAMESPACE = 'urn:partner.soap.sforce.com';
 	
-  function SforcePartnerClient() {
+  function __construct() {
     $this->namespace = self::PARTNER_NAMESPACE;
   }
   


### PR DESCRIPTION
Future versions of PHP will not allow use of class name as constructor.
