### PR TITLE
Use __construct instead of class name for constructor

### DIFF
--- a/soapclient/SforceEnterpriseClient.php
+++ b/soapclient/SforceEnterpriseClient.php
@@ -38,7 +38,7 @@ require_once ('SforceBaseClient.php');
 class SforceEnterpriseClient extends SforceBaseClient {
   const ENTERPRISE_NAMESPACE = 'urn:enterprise.soap.sforce.com';
 
-  function SforceEnterpriseClient() {
+  function __construct() {
     $this->namespace = self::ENTERPRISE_NAMESPACE;
   }
 


### PR DESCRIPTION
Future versions of PHP will not allow use of class name as constructor.
