### PR TITLE
Adding header validation for null sessionId

### DIFF
--- a/soapclient/SforceBaseClient.php
+++ b/soapclient/SforceBaseClient.php
@@ -322,8 +322,9 @@ class SforceBaseClient {
 			}
 		}
 		
-		
-		$this->sforce->__setSoapHeaders($header_array);
+		if (!empty(array_filter($header_array))) {
+	    		$this->sforce->__setSoapHeaders($header_array);
+		}
 	}
 
 	public function setAssignmentRuleHeader($header) {


### PR DESCRIPTION
When sessionId is NULL $header_array ia an array with one NULL element. In this situation __setSoapHeaders raises Exception SoapClient::__setSoapHeaders(): Invalid SOAP header